### PR TITLE
Allow subscription to multiple topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.1.X] - 2018.02.19
 
 - Init for open source
+- Allow multiple topic subscriptions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Init for open source
 - Allow multiple topic subscriptions
+- Add travis badge

--- a/README.md
+++ b/README.md
@@ -108,12 +108,12 @@ defmodule ExchangeRateController do
 
   ...
 
-  # Sample action to display USD to EUR exchange price
+  # Sample action to display USD to EUR exchange rates
   def show(conn, _params) do
     rates = %{rates: Ticker.fetch()}
     chunk = %Chunk(data: Poison.encode!(rates))
 
-    SSE.stream(conn, {@topic, chunk})
+    SSE.stream(conn, {[@topic], chunk})
   end
 
   ...
@@ -140,9 +140,9 @@ defmodule Ticker do
   end
 
   def init(_) do
-    # Let's update the price info every second
+    # Let's update the rates info every second
     update_exchange_rates_later()
-    {:ok, fetch_price()}
+    {:ok, fetch_rates()}
   end
 
   def handle_info(:update_exchange_rates, state) do
@@ -193,7 +193,7 @@ defmodule ExchangeRateController do
 
     conn
     |> Conn.put_resp_header("Access-Control-Allow-Origin", "*")
-    |> SSE.stream({@topic, chunk})
+    |> SSE.stream({[@topic], chunk})
   end
 
   ...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SSE
 
+[![Build Status](https://travis-ci.org/mustafaturan/sse.svg?branch=master)](https://travis-ci.org/mustafaturan/sse)
+
 Server Sent Events for Elixir/Plug.
 
 Server-Sent Events (SSE) is a lightweight and standardized protocol for pushing notifications from a HTTP server to a client. In contrast to WebSocket, which offers bi-directional communication, SSE only allows for one-way communication from the server to the client. If that’s all you need, SSE has the advantages to be much simpler, to rely on HTTP 1.1 only and to offer retry semantics on broken connections by the browser.

--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule SSE.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:event_bus, ">= 1.0.0"},
+      {:event_bus, ">= 1.2.0"},
       {:plug, "~> 1.4.4"},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:dialyxir, "~> 0.5.1", only: :dev, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [], [], "hexpm"},
-  "event_bus": {:hex, :event_bus, "1.1.2", "d19993e16d55b61c5eb907572334ad31a6c8b0c675f1e3a20e686465cfbd45ca", [:mix], [], "hexpm"},
+  "event_bus": {:hex, :event_bus, "1.2.0", "c0235b76f7b5ace00a79dcd7cd3cd02d71798e0d0fdb7ea2ededd1e2dc51fce8", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.8.1", "0bbf67f22c7dbf7503981d21a5eef5db8bbc3cb86e70d3798e8c802c74fa5e27", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "exjsx": {:hex, :exjsx, "4.0.0", "60548841e0212df401e38e63c0078ec57b33e7ea49b032c796ccad8cde794b5c", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/sse/server_test.exs
+++ b/test/sse/server_test.exs
@@ -1,5 +1,5 @@
 defmodule SSE.ServerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   use Plug.Test
   use SSE.ConnCase
   alias SSE.{Chunk, Server}
@@ -19,6 +19,17 @@ defmodule SSE.ServerTest do
 
     chunk = %Chunk{data: "Hi there!"}
     conn = Server.stream(conn, {@topic, chunk})
+
+    refute is_nil(Process.get(:timer_ref))
+    assert conn.state == :chunked
+    assert conn.status == 200
+  end
+
+  test "stream multiple topics", %{conn: conn} do
+    Process.send_after(self(), {:close}, 300)
+
+    chunk = %Chunk{data: "Hi there!"}
+    conn = Server.stream(conn, {[@topic, :another_event_occured], chunk})
 
     refute is_nil(Process.get(:timer_ref))
     assert conn.state == :chunked
@@ -46,24 +57,24 @@ defmodule SSE.ServerTest do
 
   test "stream and send a new event chunk", %{conn: conn} do
     pid = spawn(fn -> stream_chunk(conn) end)
-    event_watcher_id = Process.whereis EventBus.Watcher
+    event_watcher_id = Process.whereis EventBus.Manager.Observation
 
     :erlang.trace(pid, true, [:receive])
     :erlang.trace(event_watcher_id, true, [:receive])
+
+    Process.sleep(1000)
 
     chunk = %Chunk{data: "Hi again!"}
     event = %EventBus.Model.Event{id: 1, data: chunk, topic: @topic}
     EventBus.notify(event)
 
-    Process.sleep(3000)
-    Process.send_after(pid, {:close}, 6000)
-
-    assert_received {:trace, ^pid, :receive, {:sse, :test_sse_sent, _}}
-    assert_received {:trace, ^event_watcher_id, :receive,
-      {:"$gen_cast", {:mark_as_completed, _}}}
+    Process.send_after(pid, {:close}, 3000)
+    assert_receive {:trace, ^pid, :receive, {:sse, :test_sse_sent, _}}, 3000
+    assert_receive {:trace, ^event_watcher_id, :receive,
+      {:"$gen_cast", {:mark_as_completed, _}}}, 3000
   end
 
-  def stream_chunk(conn) do
+  defp stream_chunk(conn) do
     chunk = %Chunk{data: "test sse event data"}
     Server.stream(conn, {:test_sse_sent, chunk})
   end


### PR DESCRIPTION
## Description
This PR allows SSE client to subscribe multiple `event_bus` topics on stream function.

### Changes

- [x] Allow SSE client to subscribe multiple `event_bus` topics on stream function
- [x] Update `event_bus` dependency version
- [x] Fix tests for travis
- [x] Add travis badge

### Is it ready?

- [x] The changes have only one commit (if possible please answer the why question with your commit message, and ofcourse a commit may have multiple messages)
- [x] The changes don't break current functionality
- [x] All tests are covered and passing travis
- [x] Used Elixir formatter for only modified file and fixed any of them breaks current consistency.
- [x] Added specs and docs if a new function introduced
- [x] Updated specs and docs if changed any params of a function
- [x] Updated changelog
- [x] Updated readme
- [x] Didn't bump the version

### References

- Issue NA
