### PR TITLE
Move the keep alive chunk builder into a function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ...
 
-## [0.1.X] - 2018.02.19
+## [0.1.X] - 2018.02.26
 
 - Init for open source
 - Allow multiple topic subscriptions
 - Add travis badge
+- Add comment tag with default value 'KA' for keep alive chunks

--- a/lib/sse/server.ex
+++ b/lib/sse/server.ex
@@ -56,7 +56,7 @@ defmodule SSE.Server do
         send_sse(conn, event.data, listener)
 
       {:send_iddle} ->
-        send_sse(conn, %Chunk{data: []}, listener)
+        send_sse(conn, keep_alive_chunk(), listener)
 
       {:close} ->
         unsubscribe_sse(listener)
@@ -94,5 +94,11 @@ defmodule SSE.Server do
     new_ref = Process.send_after(self(), {:send_iddle}, Config.keep_alive())
     old_ref = Process.put(:timer_ref, new_ref)
     unless is_nil(old_ref), do: Process.cancel_timer(old_ref)
+  end
+
+  # Keep alive Chunk struct
+  @spec keep_alive_chunk() :: Chunk.t()
+  defp keep_alive_chunk do
+    %Chunk{comment: "KA", data: []}
   end
 end


### PR DESCRIPTION
//cc @mustafaturan

### Description
This PR changes move the keep alive chunk builder into a function with the predefined comment data `KA`.

### Changes

- [x] Move keep alive builder into its own function
- [x] Add the missing comment data on the 'keep alive chunk'

### Is it ready?

- [x] The changes have only one commit (if possible please answer the why question with your commit message, and of course a commit may have multiple messages)
- [x] The changes don't break current functionality
- [x] All tests are covered and passing travis
- [x] Used Elixir formatter for only modified file and fixed any of them breaks current consistency.
- [x] Added specs and docs if a new function introduced
- [x] Updated specs and docs if changed any params of a function
- [x] Updated changelog
- [x] Didn't bump the version

### References

- Issue NA
